### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,13 @@ diy-django
    :alt: pypi license
 
 .. image:: https://readthedocs.org/projects/diy-django/badge/
-   :target: http://diy-django.readthedocs.org/en/latest/
+   :target: https://diy-django.readthedocs.io/en/latest/
    :alt: documentation
 
-http://diy-django.readthedocs.org
+https://diy-django.readthedocs.io
 
 Features:
 
-- Email as Username http://diy-django.readthedocs.org/en/latest/emailauth.html
-- AJAX File Upload Widget with Progress http://diy-django.readthedocs.org/en/latest/ajaxupload.html
-- Markdown http://diy-django.readthedocs.org/en/latest/markdown.html
+- Email as Username https://diy-django.readthedocs.io/en/latest/emailauth.html
+- AJAX File Upload Widget with Progress https://diy-django.readthedocs.io/en/latest/ajaxupload.html
+- Markdown https://diy-django.readthedocs.io/en/latest/markdown.html

--- a/diydjango/__init__.py
+++ b/diydjango/__init__.py
@@ -1,5 +1,5 @@
 '''
 diy-django
 
-For usage, see http://diy-django.readthedocs.org/
+For usage, see https://diy-django.readthedocs.io/
 '''


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.